### PR TITLE
Fix wrong labelling of second parameter of map

### DIFF
--- a/src/remote-data.js
+++ b/src/remote-data.js
@@ -45,8 +45,8 @@ RemoteData.chain = curry((callback, remote) => // eslint-disable-line no-confusi
 RemoteData.andThen = RemoteData.chain;
 
 // map :: (b -> c) -> RemoteData a b -> RemoteData a c
-RemoteData.map = curry((transform, maybe) =>
-  RemoteData.chain(compose(RemoteData.of, transform), maybe));
+RemoteData.map = curry((transform, remote) =>
+  RemoteData.chain(compose(RemoteData.of, transform), remote));
 
 // ap :: Apply (b -> c) -> RemoteData a b -> RemoteData a c
 RemoteData.ap = curry((left, right) =>


### PR DESCRIPTION
The second parameter of the static `map` should be called `remote` and not `maybe`.